### PR TITLE
feat: support Linux CLI emoji export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ tools/wechat-key-dumper/*.dylib
 cli/target
 scripts/*bak*
 
+# WeChat account data and export artifacts
+emoticon_dbkey*.txt
+emoticon_dbkey*.wxid
+emoticon_urls*.txt
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -169,17 +169,17 @@ wxemoticon export
 ### 指定 `wxid` 的完整示例
 
 ```bash
-# 1) 先列出账号，拿到目标 wxid（例如 wxid_p5stvq48u5mv12_57c3）
+# 1) 先列出账号，拿到目标 wxid（例如 wxid_xxx）
 wxemoticon urls --list-accounts
 
 # 2) 指定 wxid 抓取/刷新 db key
-wxemoticon key --wxid "wxid_p5stvq48u5mv12_57c3"
+wxemoticon key --wxid "wxid_xxx"
 
 # 3) 指定 wxid 导出 URL 列表（可选）
-wxemoticon urls --wxid "wxid_p5stvq48u5mv12_57c3"
+wxemoticon urls --wxid "wxid_xxx"
 
 # 4) 指定 wxid 直接导出表情包图片
-wxemoticon export --wxid "wxid_p5stvq48u5mv12_57c3"
+wxemoticon export --wxid "wxid_xxx"
 ```
 
 如果你想做脚本化（不走交互），可以加 `--no-interactive` 与 `--json`：

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ wxemoticon export --urls-file /tmp/emoticon_urls.txt
 
 ## CLI（命令行方式）
 
-如果你更喜欢命令行，可使用 `wxemoticon`（macOS）。
+如果你更喜欢命令行，可使用 `wxemoticon`（macOS / Linux）。
 
 安装方式 A：安装脚本（默认，零配置）
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# 导出微信表情包（macOS）
+# 导出微信表情包（macOS / Linux）
 
 [![release](https://github.com/liusheng22/export-wechat-emoji/actions/workflows/release.yml/badge.svg)](https://github.com/liusheng22/export-wechat-emoji/actions/workflows/release.yml)
 
 > 一键导出微信收藏表情包，方便批量导入飞书、企微、钉钉等平台。
 
-> 仅支持 macOS。
+> GUI 目前支持 macOS；`wxemoticon` 命令行工具支持 macOS 和 Linux。
 
 ## 功能概览
 
@@ -13,6 +13,51 @@
 - 导出支持每 50 张分组或不分组
 - 支持断点续跑（跳过已存在文件）与导出统计
 - 提供可选 CLI：`wxemoticon`
+
+## Linux CLI（Ubuntu/Debian x86_64）
+
+已适配腾讯官方 Linux 微信 4.x（默认程序 `/opt/wechat/wechat`）。Linux 版当前仅提供命令行工具，不包含 GUI 或 `.deb` 安装包。
+
+### 从源码构建
+
+需要 Rust stable、`build-essential` 和 `pkg-config`：
+
+```bash
+sudo apt update
+sudo apt install -y build-essential pkg-config
+git clone https://github.com/liusheng22/export-wechat-emoji.git
+cd export-wechat-emoji
+cargo build --manifest-path cli/Cargo.toml --release
+install -Dm755 cli/target/release/wxemoticon ~/.local/bin/wxemoticon
+```
+
+确保 `~/.local/bin` 已加入 `PATH`，然后执行：
+
+```bash
+# 查看账号（优先读取 XDG 文档目录，并兼容 ~/Documents 和 ~/文档）
+wxemoticon urls --list-accounts
+
+# 直接导出；需要重新抓 key 时会提示先退出微信
+wxemoticon export
+```
+
+非默认安装或数据位置可显式指定：
+
+```bash
+wxemoticon \
+  --wechat-bin /opt/wechat/wechat \
+  --wechat-data-dir "$HOME/文档/xwechat_files" \
+  export
+```
+
+Linux 自动抓 key 会启动一次官方微信，并仅读取本次启动的微信进程内存；找到与目标 `emoticon.db` 首页 HMAC 匹配的 key 后立即停止该进程。若微信本身无法启动，或系统策略禁止读取 `/proc/<pid>/mem`，仍可先提供已有 key 生成 URL，再从 URL 文件导出：
+
+```bash
+wxemoticon urls --key-file /path/to/emoticon_dbkey.txt --out /tmp/emoticon_urls.txt
+wxemoticon export --urls-file /tmp/emoticon_urls.txt
+```
+
+缓存与日志默认写入 `~/.local/share/wxemoticon`，图片默认导出到 `~/Downloads`。
 
 ## 下载与安装（GUI）
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "wxemoticon"
 version = "0.1.4"
 edition = "2021"
 license = "MIT"
-description = "macOS 微信表情包工具：一键抓取 db key / 导出 URL / 导出表情包图片（无需 SIP）"
+description = "macOS/Linux 微信表情包工具：抓取 db key / 导出 URL / 导出表情包图片"
 
 [dependencies]
 anyhow = "1"

--- a/cli/src/linux.rs
+++ b/cli/src/linux.rs
@@ -1,0 +1,607 @@
+use anyhow::{anyhow, Context};
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{FileExt, MetadataExt};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use hmac::{Hmac, Mac};
+use pbkdf2::pbkdf2_hmac_array;
+use sha2::Sha512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MemoryRegion {
+    pub(crate) start: u64,
+    pub(crate) end: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct KeyCandidate {
+    pub(crate) key: [u8; 32],
+    pub(crate) salt: Option<[u8; 16]>,
+}
+
+fn xdg_documents_dir(home: &Path) -> Option<PathBuf> {
+    let config = std::fs::read_to_string(home.join(".config/user-dirs.dirs")).ok()?;
+    let value = config.lines().find_map(|line| {
+        line.trim()
+            .strip_prefix("XDG_DOCUMENTS_DIR=")
+            .map(str::trim)
+    })?;
+    let value = value.strip_prefix('"')?.strip_suffix('"')?;
+    if let Some(relative) = value.strip_prefix("$HOME/") {
+        return Some(home.join(relative));
+    }
+    let path = PathBuf::from(value);
+    path.is_absolute().then_some(path)
+}
+
+pub(crate) fn parse_readable_regions(maps: &str) -> Vec<MemoryRegion> {
+    maps.lines()
+        .filter_map(|line| {
+            let mut parts = line.split_whitespace();
+            let range = parts.next()?;
+            let permissions = parts.next()?;
+            if !permissions.starts_with('r') {
+                return None;
+            }
+            let (start, end) = range.split_once('-')?;
+            let start = u64::from_str_radix(start, 16).ok()?;
+            let end = u64::from_str_radix(end, 16).ok()?;
+            (end > start).then_some(MemoryRegion { start, end })
+        })
+        .collect()
+}
+
+fn decode_hex_array<const N: usize>(value: &[u8]) -> Option<[u8; N]> {
+    if value.len() != N * 2 || !value.iter().all(u8::is_ascii_hexdigit) {
+        return None;
+    }
+    let decoded = hex::decode(value).ok()?;
+    decoded.try_into().ok()
+}
+
+pub(crate) fn extract_key_candidates(data: &[u8]) -> Vec<KeyCandidate> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    let mut cursor = 0usize;
+
+    while cursor + 3 <= data.len() {
+        let Some(relative_start) = data[cursor..].windows(2).position(|pair| pair == b"x'") else {
+            break;
+        };
+        let value_start = cursor + relative_start + 2;
+        let search_end = (value_start + 193).min(data.len());
+        let Some(relative_end) = data[value_start..search_end]
+            .iter()
+            .position(|byte| *byte == b'\'')
+        else {
+            cursor = value_start;
+            continue;
+        };
+        let value_end = value_start + relative_end;
+        let value = &data[value_start..value_end];
+        cursor = value_end + 1;
+
+        if !(64..=192).contains(&value.len()) || !value.len().is_multiple_of(2) {
+            continue;
+        }
+        let Some(key) = decode_hex_array::<32>(&value[..64]) else {
+            continue;
+        };
+        let salt = if value.len() >= 96 {
+            decode_hex_array::<16>(&value[value.len() - 32..])
+        } else {
+            None
+        };
+        let candidate = KeyCandidate { key, salt };
+        if seen.insert(candidate) {
+            out.push(candidate);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+pub(crate) fn extract_key_candidates_from_chunks<I>(chunks: I) -> Vec<KeyCandidate>
+where
+    I: IntoIterator<Item = Vec<u8>>,
+{
+    const OVERLAP: usize = 256;
+    let mut tail = Vec::new();
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+
+    for chunk in chunks {
+        tail.extend_from_slice(&chunk);
+        for candidate in extract_key_candidates(&tail) {
+            if seen.insert(candidate) {
+                out.push(candidate);
+            }
+        }
+        if tail.len() > OVERLAP {
+            tail.drain(..tail.len() - OVERLAP);
+        }
+    }
+    out
+}
+
+pub(crate) fn is_wechat_process_name(name: &str) -> bool {
+    matches!(
+        name.trim().to_ascii_lowercase().as_str(),
+        "wechat" | "wechatappex" | "weixin"
+    )
+}
+
+pub(crate) fn parse_child_pids(value: &str) -> Vec<u32> {
+    let mut seen = HashSet::new();
+    value
+        .split_whitespace()
+        .filter_map(|token| token.parse::<u32>().ok())
+        .filter(|pid| seen.insert(*pid))
+        .collect()
+}
+
+fn process_name(pid: u32) -> Option<String> {
+    std::fs::read_to_string(format!("/proc/{pid}/comm"))
+        .ok()
+        .map(|name| name.trim().to_string())
+}
+
+fn process_belongs_to_current_user(pid: u32) -> bool {
+    let Ok(self_uid) = std::fs::metadata("/proc/self").map(|meta| meta.uid()) else {
+        return false;
+    };
+    std::fs::metadata(format!("/proc/{pid}"))
+        .map(|meta| meta.uid() == self_uid)
+        .unwrap_or(false)
+}
+
+fn wechat_pids() -> HashSet<u32> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return HashSet::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.parse::<u32>().ok())
+        })
+        .filter(|pid| {
+            process_belongs_to_current_user(*pid)
+                && process_name(*pid)
+                    .as_deref()
+                    .is_some_and(is_wechat_process_name)
+        })
+        .collect()
+}
+
+fn new_process_ids(before: &HashSet<u32>, after: &HashSet<u32>) -> Vec<u32> {
+    let mut pids: Vec<u32> = after.difference(before).copied().collect();
+    pids.sort_unstable();
+    pids
+}
+
+pub(crate) fn wechat_is_running() -> bool {
+    !wechat_pids().is_empty()
+}
+
+fn descendants(root: u32) -> Vec<u32> {
+    let mut out = vec![root];
+    let mut cursor = 0usize;
+    let mut seen = HashSet::from([root]);
+    while cursor < out.len() {
+        let pid = out[cursor];
+        cursor += 1;
+        let children_path = format!("/proc/{pid}/task/{pid}/children");
+        let Ok(children) = std::fs::read_to_string(children_path) else {
+            continue;
+        };
+        for child in parse_child_pids(&children) {
+            if seen.insert(child) {
+                out.push(child);
+            }
+        }
+    }
+    out
+}
+
+fn read_database_page(path: &Path) -> anyhow::Result<[u8; 4096]> {
+    let mut page = [0u8; 4096];
+    let file =
+        File::open(path).with_context(|| format!("读取 emoticon.db 失败：{}", path.display()))?;
+    let bytes = file
+        .read_at(&mut page, 0)
+        .with_context(|| format!("读取 emoticon.db 首页失败：{}", path.display()))?;
+    if bytes != page.len() {
+        return Err(anyhow!("emoticon.db 小于 4096 字节：{}", path.display()));
+    }
+    Ok(page)
+}
+
+fn verify_raw_key(page: &[u8; 4096], key: &[u8; 32]) -> bool {
+    const SALT_SIZE: usize = 16;
+    const IV_SIZE: usize = 16;
+    const HMAC_SIZE: usize = 64;
+    const RESERVED_SIZE: usize = 80;
+
+    let salt = &page[..SALT_SIZE];
+    let mac_salt: Vec<u8> = salt.iter().map(|byte| byte ^ 0x3a).collect();
+    let mac_key = pbkdf2_hmac_array::<Sha512, 32>(key, &mac_salt, 2);
+    let iv_start = page.len() - RESERVED_SIZE;
+    let stored_hmac_start = iv_start + IV_SIZE;
+    let mut mac = match Hmac::<Sha512>::new_from_slice(&mac_key) {
+        Ok(mac) => mac,
+        Err(_) => return false,
+    };
+    mac.update(&page[SALT_SIZE..stored_hmac_start]);
+    mac.update(&1u32.to_le_bytes());
+    mac.verify_slice(&page[stored_hmac_start..stored_hmac_start + HMAC_SIZE])
+        .is_ok()
+}
+
+fn scan_process_for_key(
+    pid: u32,
+    page: &[u8; 4096],
+    target_salt: &[u8; 16],
+) -> anyhow::Result<Option<[u8; 32]>> {
+    const CHUNK_SIZE: usize = 1024 * 1024;
+    const OVERLAP: usize = 256;
+    const MAX_REGION_SIZE: u64 = 512 * 1024 * 1024;
+
+    let maps = std::fs::read_to_string(format!("/proc/{pid}/maps"))
+        .with_context(|| format!("无法读取 /proc/{pid}/maps"))?;
+    let mem = File::open(format!("/proc/{pid}/mem"))
+        .with_context(|| format!("无法读取 /proc/{pid}/mem"))?;
+    let mut buffer = vec![0u8; CHUNK_SIZE];
+
+    for region in parse_readable_regions(&maps) {
+        let region_size = region.end - region.start;
+        if region_size == 0 || region_size > MAX_REGION_SIZE {
+            continue;
+        }
+        let mut offset = region.start;
+        let mut tail = Vec::new();
+        while offset < region.end {
+            let wanted = ((region.end - offset) as usize).min(buffer.len());
+            let read = match mem.read_at(&mut buffer[..wanted], offset) {
+                Ok(0) | Err(_) => break,
+                Ok(read) => read,
+            };
+            tail.extend_from_slice(&buffer[..read]);
+            for candidate in extract_key_candidates(&tail) {
+                if candidate.salt.is_some_and(|salt| &salt != target_salt) {
+                    continue;
+                }
+                if verify_raw_key(page, &candidate.key) {
+                    return Ok(Some(candidate.key));
+                }
+            }
+            if tail.len() > OVERLAP {
+                tail.drain(..tail.len() - OVERLAP);
+            }
+            offset += read as u64;
+        }
+    }
+    Ok(None)
+}
+
+fn terminate(child: &mut Child, extra_pids: &[u32]) {
+    for pid in extra_pids {
+        let _ = Command::new("/bin/kill")
+            .args(["-TERM", &pid.to_string()])
+            .status();
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn append_log(path: &Path, message: &str) {
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(file, "{message}");
+    }
+}
+
+pub(crate) fn dump_db_key(
+    wechat_bin: &Path,
+    emoticon_db: &Path,
+    log_file: &Path,
+    timeout: Duration,
+) -> anyhow::Result<String> {
+    if !wechat_bin.is_file() {
+        return Err(anyhow!("Linux 微信程序不存在：{}", wechat_bin.display()));
+    }
+    let page = read_database_page(emoticon_db)?;
+    let target_salt: [u8; 16] = page[..16].try_into().expect("fixed-size database salt");
+    if let Some(parent) = log_file.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let _ = std::fs::write(log_file, "[info] Linux key scan started\n");
+
+    let baseline_pids = wechat_pids();
+    let mut child = Command::new(wechat_bin)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("启动 Linux 微信失败：{}", wechat_bin.display()))?;
+    let root_pid = child.id();
+    append_log(log_file, &format!("[info] launched pid={root_pid}"));
+    let started = Instant::now();
+    let mut last_permission_error = None;
+    let mut child_exited = false;
+
+    while started.elapsed() <= timeout {
+        let current_pids = wechat_pids();
+        let mut scan_pids = new_process_ids(&baseline_pids, &current_pids);
+        for pid in descendants(root_pid) {
+            if pid == root_pid
+                || process_name(pid)
+                    .as_deref()
+                    .is_some_and(is_wechat_process_name)
+            {
+                scan_pids.push(pid);
+            }
+        }
+        scan_pids.sort_unstable();
+        scan_pids.dedup();
+
+        for pid in &scan_pids {
+            match scan_process_for_key(*pid, &page, &target_salt) {
+                Ok(Some(key)) => {
+                    append_log(
+                        log_file,
+                        &format!("[info] matched target database in pid={pid}"),
+                    );
+                    let launched = new_process_ids(&baseline_pids, &wechat_pids());
+                    terminate(&mut child, &launched);
+                    return Ok(hex::encode(key));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    last_permission_error = Some(error.to_string());
+                }
+            }
+        }
+        if !child_exited && child.try_wait().ok().flatten().is_some() {
+            child_exited = true;
+        }
+        if child_exited && new_process_ids(&baseline_pids, &wechat_pids()).is_empty() {
+            return Err(anyhow!(
+                "Linux 微信在获取密钥前退出；请查看日志：{}",
+                log_file.display()
+            ));
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+
+    let launched = new_process_ids(&baseline_pids, &wechat_pids());
+    terminate(&mut child, &launched);
+    if let Some(error) = last_permission_error {
+        append_log(log_file, &format!("[warn] {error}"));
+    }
+    Err(anyhow!(
+        "等待 Linux 微信数据库密钥超时（{} 秒）；请在启动的微信中登录并打开一次表情面板。日志：{}",
+        timeout.as_secs(),
+        log_file.display()
+    ))
+}
+
+pub(crate) fn discover_data_root(home: &Path, explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
+    if let Some(path) = explicit {
+        if path.is_dir() {
+            return Ok(path.to_path_buf());
+        }
+        return Err(anyhow!("指定的微信数据目录不存在：{}", path.display()));
+    }
+
+    let mut candidates = Vec::new();
+    if let Some(documents) = xdg_documents_dir(home) {
+        candidates.push(documents.join("xwechat_files"));
+    }
+    candidates.push(home.join("Documents/xwechat_files"));
+    candidates.push(home.join("文档/xwechat_files"));
+    candidates
+        .into_iter()
+        .find(|path| path.is_dir())
+        .with_context(|| {
+            format!(
+                "未找到 Linux 微信数据目录；请使用 --wechat-data-dir 指定 xwechat_files 路径（HOME={}）",
+                home.display()
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn data_root_prefers_explicit_directory() {
+        let tmp = tempdir().unwrap();
+        let explicit = tmp.path().join("custom/xwechat_files");
+        fs::create_dir_all(&explicit).unwrap();
+
+        let actual = discover_data_root(tmp.path(), Some(&explicit)).unwrap();
+
+        assert_eq!(actual, explicit);
+    }
+
+    #[test]
+    fn data_root_discovers_english_documents_directory() {
+        let tmp = tempdir().unwrap();
+        let expected = tmp.path().join("Documents/xwechat_files");
+        fs::create_dir_all(&expected).unwrap();
+
+        let actual = discover_data_root(tmp.path(), None).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn data_root_discovers_localized_chinese_documents_directory() {
+        let tmp = tempdir().unwrap();
+        let expected = tmp.path().join("文档/xwechat_files");
+        fs::create_dir_all(&expected).unwrap();
+
+        let actual = discover_data_root(tmp.path(), None).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn data_root_uses_xdg_documents_configuration() {
+        let tmp = tempdir().unwrap();
+        let expected = tmp.path().join("Документы/xwechat_files");
+        fs::create_dir_all(&expected).unwrap();
+        fs::create_dir_all(tmp.path().join(".config")).unwrap();
+        fs::write(
+            tmp.path().join(".config/user-dirs.dirs"),
+            "XDG_DOCUMENTS_DIR=\"$HOME/Документы\"\n",
+        )
+        .unwrap();
+
+        let actual = discover_data_root(tmp.path(), None).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn data_root_rejects_missing_explicit_directory() {
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("missing");
+
+        let error = discover_data_root(tmp.path(), Some(&missing)).unwrap_err();
+
+        assert!(error.to_string().contains("不存在"));
+    }
+
+    #[test]
+    fn maps_parser_keeps_only_readable_regions() {
+        let maps = concat!(
+            "00400000-00452000 r-xp 00000000 08:02 1 /opt/wechat/wechat\n",
+            "00651000-00652000 r--p 00051000 08:02 1 /opt/wechat/wechat\n",
+            "00652000-00653000 -w-p 00052000 08:02 1 /opt/wechat/wechat\n",
+            "7ffd0000-7ffd1000 rw-p 00000000 00:00 0 [stack]\n",
+        );
+
+        let regions = parse_readable_regions(maps);
+
+        assert_eq!(
+            regions,
+            vec![
+                MemoryRegion {
+                    start: 0x0040_0000,
+                    end: 0x0045_2000,
+                },
+                MemoryRegion {
+                    start: 0x0065_1000,
+                    end: 0x0065_2000,
+                },
+                MemoryRegion {
+                    start: 0x7ffd_0000,
+                    end: 0x7ffd_1000,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn scanner_extracts_raw_key_and_matching_salt() {
+        let key = "11".repeat(32);
+        let salt = "ab".repeat(16);
+        let bytes = format!("noise x'{key}{salt}' tail");
+
+        let candidates = extract_key_candidates(bytes.as_bytes());
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].key, [0x11; 32]);
+        assert_eq!(candidates[0].salt, Some([0xab; 16]));
+    }
+
+    #[test]
+    fn scanner_deduplicates_plain_raw_keys() {
+        let key = "42".repeat(32);
+        let bytes = format!("x'{key}' x'{key}'");
+
+        let candidates = extract_key_candidates(bytes.as_bytes());
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].key, [0x42; 32]);
+        assert_eq!(candidates[0].salt, None);
+    }
+
+    #[test]
+    fn scanner_rejects_non_hex_and_wrong_length_values() {
+        let bytes =
+            b"x'not-a-key' x'0011' x'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'";
+
+        assert!(extract_key_candidates(bytes).is_empty());
+    }
+
+    #[test]
+    fn chunk_scanner_preserves_pattern_across_boundaries() {
+        let key = "7f".repeat(32);
+        let salt = "08".repeat(16);
+        let bytes = format!("prefix-x'{key}{salt}'-suffix").into_bytes();
+        let chunks = vec![
+            bytes[..31].to_vec(),
+            bytes[31..73].to_vec(),
+            bytes[73..].to_vec(),
+        ];
+
+        let candidates = extract_key_candidates_from_chunks(chunks);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].key, [0x7f; 32]);
+        assert_eq!(candidates[0].salt, Some([0x08; 16]));
+    }
+
+    #[test]
+    fn process_name_matching_accepts_only_wechat_binaries() {
+        assert!(is_wechat_process_name("wechat"));
+        assert!(is_wechat_process_name("WeChatAppEx"));
+        assert!(is_wechat_process_name("weixin"));
+        assert!(!is_wechat_process_name("wechat-export-helper"));
+        assert!(!is_wechat_process_name("bash"));
+    }
+
+    #[test]
+    fn children_parser_ignores_invalid_tokens_and_duplicates() {
+        assert_eq!(parse_child_pids("12 34 bad 12\n"), vec![12, 34]);
+    }
+
+    #[test]
+    fn raw_key_is_verified_against_database_page_hmac() {
+        let key = [0x33; 32];
+        let mut page = [0u8; 4096];
+        for (index, byte) in page[..4032].iter_mut().enumerate() {
+            *byte = (index % 251) as u8;
+        }
+        let salt = page[..16].to_vec();
+        let mac_salt: Vec<u8> = salt.iter().map(|byte| byte ^ 0x3a).collect();
+        let mac_key = pbkdf2_hmac_array::<Sha512, 32>(&key, &mac_salt, 2);
+        let mut mac = Hmac::<Sha512>::new_from_slice(&mac_key).unwrap();
+        mac.update(&page[16..4032]);
+        mac.update(&1u32.to_le_bytes());
+        page[4032..].copy_from_slice(&mac.finalize().into_bytes());
+
+        assert!(verify_raw_key(&page, &key));
+        assert!(!verify_raw_key(&page, &[0x44; 32]));
+    }
+
+    #[test]
+    fn new_process_ids_exclude_preexisting_wechat_processes() {
+        let before = HashSet::from([10, 20]);
+        let after = HashSet::from([20, 30, 40]);
+
+        assert_eq!(new_process_ids(&before, &after), vec![30, 40]);
+    }
+}

--- a/cli/src/linux.rs
+++ b/cli/src/linux.rs
@@ -1,12 +1,15 @@
 use anyhow::{anyhow, Context};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
-use std::os::unix::fs::{FileExt, MetadataExt};
+use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const SESSION_TOKEN_ENV: &str = "WXEMOTICON_SESSION_TOKEN";
 
 use hmac::{Hmac, Mac};
 use pbkdf2::pbkdf2_hmac_array;
@@ -24,8 +27,19 @@ pub(crate) struct KeyCandidate {
     pub(crate) salt: Option<[u8; 16]>,
 }
 
-fn xdg_documents_dir(home: &Path) -> Option<PathBuf> {
-    let config = std::fs::read_to_string(home.join(".config/user-dirs.dirs")).ok()?;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessIdentity {
+    pid: u32,
+    process_group: u32,
+    start_time: u64,
+    executable: PathBuf,
+}
+
+fn xdg_documents_dir(home: &Path, config_home: Option<&Path>) -> Option<PathBuf> {
+    let config_dir = config_home
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| home.join(".config"));
+    let config = std::fs::read_to_string(config_dir.join("user-dirs.dirs")).ok()?;
     let value = config.lines().find_map(|line| {
         line.trim()
             .strip_prefix("XDG_DOCUMENTS_DIR=")
@@ -136,19 +150,30 @@ pub(crate) fn is_wechat_process_name(name: &str) -> bool {
     )
 }
 
-pub(crate) fn parse_child_pids(value: &str) -> Vec<u32> {
-    let mut seen = HashSet::new();
-    value
-        .split_whitespace()
-        .filter_map(|token| token.parse::<u32>().ok())
-        .filter(|pid| seen.insert(*pid))
-        .collect()
-}
-
 fn process_name(pid: u32) -> Option<String> {
     std::fs::read_to_string(format!("/proc/{pid}/comm"))
         .ok()
         .map(|name| name.trim().to_string())
+}
+
+fn parse_process_stat(pid: u32, stat: &str, executable: PathBuf) -> Option<ProcessIdentity> {
+    let close_paren = stat.rfind(')')?;
+    let fields: Vec<&str> = stat.get(close_paren + 1..)?.split_whitespace().collect();
+    // The slice starts at field 3 (state): pgrp is field 5, starttime is field 22.
+    let process_group = fields.get(2)?.parse().ok()?;
+    let start_time = fields.get(19)?.parse().ok()?;
+    Some(ProcessIdentity {
+        pid,
+        process_group,
+        start_time,
+        executable,
+    })
+}
+
+fn process_identity(pid: u32) -> Option<ProcessIdentity> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let executable = std::fs::read_link(format!("/proc/{pid}/exe")).ok()?;
+    parse_process_stat(pid, &stat, executable)
 }
 
 fn process_belongs_to_current_user(pid: u32) -> bool {
@@ -181,34 +206,50 @@ fn wechat_pids() -> HashSet<u32> {
         .collect()
 }
 
-fn new_process_ids(before: &HashSet<u32>, after: &HashSet<u32>) -> Vec<u32> {
-    let mut pids: Vec<u32> = after.difference(before).copied().collect();
-    pids.sort_unstable();
-    pids
-}
-
 pub(crate) fn wechat_is_running() -> bool {
     !wechat_pids().is_empty()
 }
 
-fn descendants(root: u32) -> Vec<u32> {
-    let mut out = vec![root];
-    let mut cursor = 0usize;
-    let mut seen = HashSet::from([root]);
-    while cursor < out.len() {
-        let pid = out[cursor];
-        cursor += 1;
-        let children_path = format!("/proc/{pid}/task/{pid}/children");
-        let Ok(children) = std::fs::read_to_string(children_path) else {
-            continue;
-        };
-        for child in parse_child_pids(&children) {
-            if seen.insert(child) {
-                out.push(child);
-            }
-        }
-    }
-    out
+fn new_session_token() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{}-{nanos}", std::process::id())
+}
+
+fn process_has_session_token(pid: u32, token: &str) -> bool {
+    let Ok(environ) = std::fs::read(format!("/proc/{pid}/environ")) else {
+        return false;
+    };
+    let expected = format!("{SESSION_TOKEN_ENV}={token}");
+    environ
+        .split(|byte| *byte == 0)
+        .any(|entry| entry == expected.as_bytes())
+}
+
+fn session_members(token: &str, process_group: u32, install_root: &Path) -> Vec<ProcessIdentity> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    let mut members: Vec<ProcessIdentity> = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .and_then(|name| name.parse::<u32>().ok())
+        })
+        .filter(|pid| process_belongs_to_current_user(*pid))
+        .filter_map(process_identity)
+        .filter(|identity| {
+            identity.executable.starts_with(install_root)
+                && (process_has_session_token(identity.pid, token)
+                    || identity.process_group == process_group)
+        })
+        .collect();
+    members.sort_by_key(|identity| identity.pid);
+    members
 }
 
 fn read_database_page(path: &Path) -> anyhow::Result<[u8; 4096]> {
@@ -249,10 +290,10 @@ fn scan_process_for_key(
     pid: u32,
     page: &[u8; 4096],
     target_salt: &[u8; 16],
+    deadline: Instant,
 ) -> anyhow::Result<Option<[u8; 32]>> {
     const CHUNK_SIZE: usize = 1024 * 1024;
     const OVERLAP: usize = 256;
-    const MAX_REGION_SIZE: u64 = 512 * 1024 * 1024;
 
     let maps = std::fs::read_to_string(format!("/proc/{pid}/maps"))
         .with_context(|| format!("无法读取 /proc/{pid}/maps"))?;
@@ -261,13 +302,12 @@ fn scan_process_for_key(
     let mut buffer = vec![0u8; CHUNK_SIZE];
 
     for region in parse_readable_regions(&maps) {
-        let region_size = region.end - region.start;
-        if region_size == 0 || region_size > MAX_REGION_SIZE {
-            continue;
-        }
         let mut offset = region.start;
         let mut tail = Vec::new();
         while offset < region.end {
+            if Instant::now() >= deadline {
+                return Ok(None);
+            }
             let wanted = ((region.end - offset) as usize).min(buffer.len());
             let read = match mem.read_at(&mut buffer[..wanted], offset) {
                 Ok(0) | Err(_) => break,
@@ -291,18 +331,86 @@ fn scan_process_for_key(
     Ok(None)
 }
 
-fn terminate(child: &mut Child, extra_pids: &[u32]) {
-    for pid in extra_pids {
-        let _ = Command::new("/bin/kill")
-            .args(["-TERM", &pid.to_string()])
-            .status();
+fn send_signal(identity: &ProcessIdentity, signal: &str) {
+    if process_identity(identity.pid).as_ref() != Some(identity) {
+        return;
     }
-    let _ = child.kill();
-    let _ = child.wait();
+    let _ = Command::new("/bin/kill")
+        .args([signal, &identity.pid.to_string()])
+        .status();
+}
+
+struct LaunchedWechat {
+    child: Child,
+    session_token: String,
+    process_group: u32,
+    install_root: PathBuf,
+    tracked: HashMap<u32, ProcessIdentity>,
+    cleaned: bool,
+}
+
+impl LaunchedWechat {
+    fn refresh(&mut self) -> Vec<ProcessIdentity> {
+        let members = session_members(&self.session_token, self.process_group, &self.install_root);
+        for identity in &members {
+            self.tracked.insert(identity.pid, identity.clone());
+        }
+        members
+    }
+
+    fn has_live_members(&self) -> bool {
+        self.tracked
+            .values()
+            .any(|identity| process_identity(identity.pid).as_ref() == Some(identity))
+    }
+
+    fn cleanup(&mut self) {
+        self.cleanup_with_grace(Duration::from_secs(3), Duration::from_secs(1));
+    }
+
+    fn cleanup_with_grace(&mut self, term_grace: Duration, kill_grace: Duration) {
+        if self.cleaned {
+            return;
+        }
+        self.cleaned = true;
+        let deadline = Instant::now() + term_grace;
+        while Instant::now() < deadline {
+            for identity in self.refresh() {
+                send_signal(&identity, "-TERM");
+            }
+            if self.child.try_wait().ok().flatten().is_some() && !self.has_live_members() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+        let reap_deadline = Instant::now() + kill_grace;
+        while Instant::now() < reap_deadline {
+            for identity in self.refresh() {
+                send_signal(&identity, "-KILL");
+            }
+            let _ = self.child.kill();
+            if self.child.try_wait().ok().flatten().is_some() && !self.has_live_members() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for LaunchedWechat {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
 }
 
 fn append_log(path: &Path, message: &str) {
-    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .open(path)
+    {
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
         let _ = writeln!(file, "{message}");
     }
 }
@@ -321,45 +429,56 @@ pub(crate) fn dump_db_key(
     if let Some(parent) = log_file.parent() {
         std::fs::create_dir_all(parent).ok();
     }
-    let _ = std::fs::write(log_file, "[info] Linux key scan started\n");
+    let mut log_options = OpenOptions::new();
+    log_options
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600);
+    if let Ok(mut log) = log_options.open(log_file) {
+        let _ = std::fs::set_permissions(log_file, std::fs::Permissions::from_mode(0o600));
+        let _ = log.write_all(b"[info] Linux key scan started\n");
+    }
 
-    let baseline_pids = wechat_pids();
-    let mut child = Command::new(wechat_bin)
+    let canonical_bin = std::fs::canonicalize(wechat_bin)
+        .with_context(|| format!("解析 Linux 微信程序路径失败：{}", wechat_bin.display()))?;
+    let install_root = canonical_bin
+        .parent()
+        .ok_or_else(|| anyhow!("无法确定 Linux 微信安装目录：{}", canonical_bin.display()))?
+        .to_path_buf();
+    let session_token = new_session_token();
+    let child = Command::new(&canonical_bin)
+        .env(SESSION_TOKEN_ENV, &session_token)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
+        .process_group(0)
         .spawn()
         .with_context(|| format!("启动 Linux 微信失败：{}", wechat_bin.display()))?;
     let root_pid = child.id();
+    let mut launched = LaunchedWechat {
+        child,
+        session_token,
+        process_group: root_pid,
+        install_root,
+        tracked: HashMap::new(),
+        cleaned: false,
+    };
     append_log(log_file, &format!("[info] launched pid={root_pid}"));
     let started = Instant::now();
+    let deadline = started + timeout;
     let mut last_permission_error = None;
     let mut child_exited = false;
 
-    while started.elapsed() <= timeout {
-        let current_pids = wechat_pids();
-        let mut scan_pids = new_process_ids(&baseline_pids, &current_pids);
-        for pid in descendants(root_pid) {
-            if pid == root_pid
-                || process_name(pid)
-                    .as_deref()
-                    .is_some_and(is_wechat_process_name)
-            {
-                scan_pids.push(pid);
-            }
-        }
-        scan_pids.sort_unstable();
-        scan_pids.dedup();
-
-        for pid in &scan_pids {
-            match scan_process_for_key(*pid, &page, &target_salt) {
+    while Instant::now() <= deadline {
+        let members = launched.refresh();
+        for identity in &members {
+            match scan_process_for_key(identity.pid, &page, &target_salt, deadline) {
                 Ok(Some(key)) => {
                     append_log(
                         log_file,
-                        &format!("[info] matched target database in pid={pid}"),
+                        &format!("[info] matched target database in pid={}", identity.pid),
                     );
-                    let launched = new_process_ids(&baseline_pids, &wechat_pids());
-                    terminate(&mut child, &launched);
                     return Ok(hex::encode(key));
                 }
                 Ok(None) => {}
@@ -368,10 +487,10 @@ pub(crate) fn dump_db_key(
                 }
             }
         }
-        if !child_exited && child.try_wait().ok().flatten().is_some() {
+        if !child_exited && launched.child.try_wait().ok().flatten().is_some() {
             child_exited = true;
         }
-        if child_exited && new_process_ids(&baseline_pids, &wechat_pids()).is_empty() {
+        if child_exited && !launched.has_live_members() {
             return Err(anyhow!(
                 "Linux 微信在获取密钥前退出；请查看日志：{}",
                 log_file.display()
@@ -380,8 +499,6 @@ pub(crate) fn dump_db_key(
         thread::sleep(Duration::from_secs(1));
     }
 
-    let launched = new_process_ids(&baseline_pids, &wechat_pids());
-    terminate(&mut child, &launched);
     if let Some(error) = last_permission_error {
         append_log(log_file, &format!("[warn] {error}"));
     }
@@ -392,7 +509,11 @@ pub(crate) fn dump_db_key(
     ))
 }
 
-pub(crate) fn discover_data_root(home: &Path, explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
+fn discover_data_root_with_config(
+    home: &Path,
+    explicit: Option<&Path>,
+    config_home: Option<&Path>,
+) -> anyhow::Result<PathBuf> {
     if let Some(path) = explicit {
         if path.is_dir() {
             return Ok(path.to_path_buf());
@@ -401,7 +522,7 @@ pub(crate) fn discover_data_root(home: &Path, explicit: Option<&Path>) -> anyhow
     }
 
     let mut candidates = Vec::new();
-    if let Some(documents) = xdg_documents_dir(home) {
+    if let Some(documents) = xdg_documents_dir(home, config_home) {
         candidates.push(documents.join("xwechat_files"));
     }
     candidates.push(home.join("Documents/xwechat_files"));
@@ -415,6 +536,11 @@ pub(crate) fn discover_data_root(home: &Path, explicit: Option<&Path>) -> anyhow
                 home.display()
             )
         })
+}
+
+pub(crate) fn discover_data_root(home: &Path, explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
+    let config_home = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
+    discover_data_root_with_config(home, explicit, config_home.as_deref())
 }
 
 #[cfg(test)]
@@ -469,6 +595,24 @@ mod tests {
         .unwrap();
 
         let actual = discover_data_root(tmp.path(), None).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn data_root_uses_custom_xdg_config_home() {
+        let tmp = tempdir().unwrap();
+        let config_home = tmp.path().join("xdg-config");
+        let expected = tmp.path().join("Docs/xwechat_files");
+        fs::create_dir_all(&expected).unwrap();
+        fs::create_dir_all(&config_home).unwrap();
+        fs::write(
+            config_home.join("user-dirs.dirs"),
+            "XDG_DOCUMENTS_DIR=\"$HOME/Docs\"\n",
+        )
+        .unwrap();
+
+        let actual = discover_data_root_with_config(tmp.path(), None, Some(&config_home)).unwrap();
 
         assert_eq!(actual, expected);
     }
@@ -574,11 +718,6 @@ mod tests {
     }
 
     #[test]
-    fn children_parser_ignores_invalid_tokens_and_duplicates() {
-        assert_eq!(parse_child_pids("12 34 bad 12\n"), vec![12, 34]);
-    }
-
-    #[test]
     fn raw_key_is_verified_against_database_page_hmac() {
         let key = [0x33; 32];
         let mut page = [0u8; 4096];
@@ -598,10 +737,76 @@ mod tests {
     }
 
     #[test]
-    fn new_process_ids_exclude_preexisting_wechat_processes() {
-        let before = HashSet::from([10, 20]);
-        let after = HashSet::from([20, 30, 40]);
+    fn process_stat_parser_extracts_group_and_start_time() {
+        let mut fields = vec!["0"; 20];
+        fields[0] = "S";
+        fields[1] = "1";
+        fields[2] = "123";
+        fields[19] = "987654";
+        let stat = format!("123 (wechat) {}", fields.join(" "));
 
-        assert_eq!(new_process_ids(&before, &after), vec![30, 40]);
+        let parsed = parse_process_stat(123, &stat, PathBuf::from("/opt/wechat/wechat")).unwrap();
+
+        assert_eq!(parsed.pid, 123);
+        assert_eq!(parsed.process_group, 123);
+        assert_eq!(parsed.start_time, 987654);
+    }
+
+    #[test]
+    fn session_token_tracks_a_process_after_setsid() {
+        let token = new_session_token();
+        let mut child = Command::new("/usr/bin/setsid")
+            .args(["/bin/sleep", "10"])
+            .env(SESSION_TOKEN_ENV, &token)
+            .spawn()
+            .unwrap();
+        let mut found = false;
+        let mut excluded_outside_install_root = false;
+        for _ in 0..40 {
+            excluded_outside_install_root = session_members(
+                &token,
+                u32::MAX,
+                Path::new("/definitely-not-the-install-root"),
+            )
+            .iter()
+            .all(|identity| identity.pid != child.id());
+            found = session_members(&token, u32::MAX, Path::new("/usr/bin"))
+                .iter()
+                .any(|identity| identity.pid == child.id());
+            if found {
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(
+            found,
+            "setsid process was not found through its session token"
+        );
+        assert!(
+            excluded_outside_install_root,
+            "token must not include executables outside the install root"
+        );
+    }
+
+    #[test]
+    fn cleanup_is_bounded_even_when_root_is_not_discoverable() {
+        let child = Command::new("/bin/sleep").arg("10").spawn().unwrap();
+        let mut launched = LaunchedWechat {
+            child,
+            session_token: "missing-token".to_string(),
+            process_group: u32::MAX,
+            install_root: PathBuf::from("/not-used"),
+            tracked: HashMap::new(),
+            cleaned: false,
+        };
+        let started = Instant::now();
+
+        launched.cleanup_with_grace(Duration::from_millis(25), Duration::from_millis(500));
+
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(launched.child.try_wait().unwrap().is_some());
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ use dialoguer::{Confirm, Input, Select};
 use hmac::{Hmac, Mac};
 use indicatif::{ProgressBar, ProgressStyle};
 use pbkdf2::pbkdf2_hmac_array;
+#[cfg(target_os = "macos")]
 use plist::Value;
 use regex::Regex;
 use reqwest::header::CONTENT_TYPE;
@@ -19,11 +20,22 @@ use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
 use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime};
 use tempfile::NamedTempFile;
 use tokio::time::Instant;
 use url::Url;
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "macos")]
+const DEFAULT_WECHAT_PATH: &str = "/Applications/WeChat.app";
+#[cfg(target_os = "linux")]
+const DEFAULT_WECHAT_PATH: &str = "/opt/wechat/wechat";
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+const DEFAULT_WECHAT_PATH: &str = "wechat";
 
 // The key dumper dylib is built by build.rs and embedded here so the CLI stays a single executable.
 #[cfg(target_os = "macos")]
@@ -34,12 +46,21 @@ static WECHAT_KEY_DUMPER_DYLIB: &[u8] = include_bytes!(env!("WXEMOTICON_KEY_DUMP
     name = "wxemoticon",
     author,
     version,
-    about = "macOS 微信表情包工具（无需 SIP）：抓取 db key / 导出 URL / 导出表情包图片"
+    about = "macOS/Linux 微信表情包工具：抓取 db key / 导出 URL / 导出表情包图片"
 )]
 struct Cli {
-    /// WeChat.app 路径（默认 /Applications/WeChat.app；也可传 /Applications/WeChat.bak.app）
-    #[arg(long, global = true, default_value = "/Applications/WeChat.app")]
+    /// 微信程序路径（Linux 默认 /opt/wechat/wechat；macOS 默认 /Applications/WeChat.app）
+    #[arg(
+        long = "wechat-bin",
+        visible_alias = "wechat-app",
+        global = true,
+        default_value = DEFAULT_WECHAT_PATH
+    )]
     wechat_app: String,
+
+    /// xwechat_files 数据目录；Linux 会自动检测 ~/Documents 和 ~/文档
+    #[arg(long, global = true)]
+    wechat_data_dir: Option<String>,
 
     /// 关闭交互提示（需要把必要参数都传全）
     #[arg(long, global = true)]
@@ -145,7 +166,7 @@ struct ExportArgs {
     wxid: Option<String>,
 
     /// 从已有 URL 文件导出（跳过抓 key/解密查询）
-    #[arg(long, hide = true)]
+    #[arg(long)]
     urls_file: Option<String>,
 
     /// 导出目录（默认 ~/Downloads/微信表情包_导出_YYYYMMDD_HHMMSS）
@@ -247,6 +268,7 @@ struct ExportResult {
     failed: usize,
 }
 
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateResult {
@@ -279,8 +301,15 @@ fn home_dir() -> anyhow::Result<PathBuf> {
 }
 
 fn default_out_dir() -> anyhow::Result<PathBuf> {
-    Ok(home_dir()?
-        .join("Library/Containers/com.tencent.xinWeChat/Data/Documents/export-wechat-emoji"))
+    #[cfg(target_os = "macos")]
+    {
+        return Ok(home_dir()?
+            .join("Library/Containers/com.tencent.xinWeChat/Data/Documents/export-wechat-emoji"));
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(home_dir()?.join(".local/share/wxemoticon"))
+    }
 }
 
 fn default_key_file() -> anyhow::Result<PathBuf> {
@@ -317,8 +346,25 @@ fn urls_log_for_wxid(wxid: &str) -> anyhow::Result<PathBuf> {
     Ok(default_out_dir()?.join(format!("emoticon_urls_{wxid}.log")))
 }
 
-fn xwechat_files_dir() -> anyhow::Result<PathBuf> {
-    Ok(home_dir()?.join("Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files"))
+fn xwechat_files_dir(explicit: Option<&str>) -> anyhow::Result<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let explicit = explicit.map(Path::new);
+        linux::discover_data_root(&home_dir()?, explicit)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(path) = explicit {
+            return resolve_user_path(path);
+        }
+        return Ok(home_dir()?
+            .join("Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files"));
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = explicit;
+        Err(anyhow!("当前操作系统不受支持"))
+    }
 }
 
 fn downloads_dir() -> anyhow::Result<PathBuf> {
@@ -350,6 +396,24 @@ fn open_dir(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+fn open_reveal(path: &Path) -> anyhow::Result<()> {
+    let target = path.parent().unwrap_or(path);
+    open_dir(target)
+}
+
+#[cfg(target_os = "linux")]
+fn open_dir(path: &Path) -> anyhow::Result<()> {
+    let status = std::process::Command::new("xdg-open")
+        .arg(path)
+        .status()
+        .context("执行 xdg-open 失败")?;
+    if !status.success() {
+        return Err(anyhow!("打开目录失败：{}", path.display()));
+    }
+    Ok(())
+}
+
 #[cfg(target_os = "macos")]
 fn wechat_is_running(wechat_app: &Path) -> bool {
     // Don't use `ps | grep` / `pgrep -f` because they may match themselves and cause false positives.
@@ -367,9 +431,7 @@ fn wechat_is_running(wechat_app: &Path) -> bool {
         .map(|n| format!("{n}/Contents/"))
         .collect();
 
-    let out = Command::new("/bin/ps")
-        .args(["-A", "-o", "args="])
-        .output();
+    let out = Command::new("/bin/ps").args(["-A", "-o", "args="]).output();
     let Ok(out) = out else { return false };
     let text = String::from_utf8_lossy(&out.stdout);
     for line in text.lines() {
@@ -404,7 +466,9 @@ fn wait_for_wechat_exit(wechat_app: &Path, no_interactive: bool) -> anyhow::Resu
     }
 
     if no_interactive {
-        return Err(anyhow!("检测到微信仍在运行：必须先完全退出微信才能继续抓取 key"));
+        return Err(anyhow!(
+            "检测到微信仍在运行：必须先完全退出微信才能继续抓取 key"
+        ));
     }
 
     loop {
@@ -419,9 +483,31 @@ fn wait_for_wechat_exit(wechat_app: &Path, no_interactive: bool) -> anyhow::Resu
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+fn wait_for_wechat_exit(_wechat_app: &Path, no_interactive: bool) -> anyhow::Result<()> {
+    if !linux::wechat_is_running() {
+        return Ok(());
+    }
+    if no_interactive {
+        return Err(anyhow!(
+            "检测到微信仍在运行：必须先完全退出微信才能继续抓取 key"
+        ));
+    }
+    loop {
+        prompt_enter_to_continue(
+            no_interactive,
+            "检测到微信仍在运行：请完全退出微信，然后按回车重新检查。",
+        )?;
+        if !linux::wechat_is_running() {
+            return Ok(());
+        }
+        eprintln!("仍检测到微信进程，请确认已完全退出。");
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn wait_for_wechat_exit(_wechat_app: &Path, _no_interactive: bool) -> anyhow::Result<()> {
-    Ok(())
+    Err(anyhow!("当前操作系统不受支持"))
 }
 
 fn normalize_hex_key(input: &str) -> Option<String> {
@@ -470,16 +556,15 @@ fn append_log(path: &Path, line: &str) {
     }
 }
 
-fn find_accounts() -> anyhow::Result<Vec<Account>> {
-    let base = xwechat_files_dir()?;
+fn find_accounts(base: &Path) -> anyhow::Result<Vec<Account>> {
     if !base.exists() {
         return Ok(vec![]);
     }
     let mut out = vec![];
-    for ent in std::fs::read_dir(&base).context("读取 xwechat_files 失败")? {
+    for ent in std::fs::read_dir(base).context("读取 xwechat_files 失败")? {
         let ent = ent?;
         let name = ent.file_name().to_string_lossy().to_string();
-        
+
         // 过滤掉微信内部已知的非账号共享目录
         let ignore_dirs = ["all_users", "Backup", "WMPF", "AppletCaches", "Update"];
         if ignore_dirs.contains(&name.as_str()) || name.starts_with('.') {
@@ -518,11 +603,15 @@ fn format_mtime(mtime: Option<SystemTime>) -> String {
     dt.format(&fmt).unwrap_or_else(|_| "未知".to_string())
 }
 
-fn select_account(accounts: &[Account], no_interactive: bool) -> anyhow::Result<Account> {
+fn select_account(
+    accounts: &[Account],
+    data_root: &Path,
+    no_interactive: bool,
+) -> anyhow::Result<Account> {
     if accounts.is_empty() {
         return Err(anyhow!(
             "未找到任何账号：请确认已登录新版微信（4.x），且目录存在：{}",
-            xwechat_files_dir()?.display()
+            data_root.display()
         ));
     }
 
@@ -559,16 +648,6 @@ fn select_account(accounts: &[Account], no_interactive: bool) -> anyhow::Result<
         .interact_on(&term_stderr())
         .context("读取选择失败")?;
     Ok(accounts[idx].clone())
-}
-
-#[cfg(not(target_os = "macos"))]
-fn ensure_macos() -> anyhow::Result<()> {
-    Err(anyhow!("wxemoticon 目前仅支持 macOS"))
-}
-
-#[cfg(target_os = "macos")]
-fn ensure_macos() -> anyhow::Result<()> {
-    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -756,8 +835,10 @@ fn dump_db_key(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_or_dump_key(
     target_wxid: &str,
+    emoticon_db: &Path,
     wechat_app: &Path,
     key_file: &Path,
     log_file: &Path,
@@ -773,7 +854,6 @@ fn get_or_dump_key(
         }
     }
 
-    ensure_macos()?;
     #[cfg(target_os = "macos")]
     {
         dump_db_key(
@@ -785,8 +865,31 @@ fn get_or_dump_key(
             timeout,
         )
     }
-    #[cfg(not(target_os = "macos"))]
-    unreachable!()
+    #[cfg(target_os = "linux")]
+    {
+        let _ = target_wxid;
+        let _ = no_interactive;
+        wait_for_wechat_exit(wechat_app, no_interactive)?;
+        let key = linux::dump_db_key(wechat_app, emoticon_db, log_file, timeout)?;
+        if let Some(parent) = key_file.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::write(key_file, format!("{key}\n"))
+            .with_context(|| format!("写入 key 文件失败：{}", key_file.display()))?;
+        Ok(key)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (
+            target_wxid,
+            emoticon_db,
+            wechat_app,
+            log_file,
+            no_interactive,
+            timeout,
+        );
+        Err(anyhow!("当前操作系统不受支持"))
+    }
 }
 
 #[derive(Debug)]
@@ -856,7 +959,7 @@ fn decrypt_db_file_v4_with_key(
 
     // SQLCipher reserved bytes per page are IV + HMAC, aligned to AES block size.
     let mut reserve = IV_SIZE + HMAC_SHA512_SIZE;
-    if reserve % AES_BLOCK_SIZE != 0 {
+    if !reserve.is_multiple_of(AES_BLOCK_SIZE) {
         reserve = ((reserve / AES_BLOCK_SIZE) + 1) * AES_BLOCK_SIZE;
     }
 
@@ -990,10 +1093,8 @@ fn score_emoticon_url(url: &str) -> i32 {
 fn best_emoticon_url_from_fields(fields: &[Option<String>]) -> Option<String> {
     let mut candidates = Vec::<String>::new();
     let mut seen = HashSet::<String>::new();
-    for f in fields {
-        if let Some(s) = f {
-            push_urls_from_string(s, &mut candidates, &mut seen);
-        }
+    for s in fields.iter().flatten() {
+        push_urls_from_string(s, &mut candidates, &mut seen);
     }
     if candidates.is_empty() {
         return None;
@@ -1066,13 +1167,9 @@ fn extract_urls_from_emoticon_db(emoticon_db: &Path, db_key: &str) -> anyhow::Re
             if seen_md5.contains(&md5) {
                 continue;
             }
-            if let Some(best) = best_emoticon_url_from_fields(&[
-                cdn,
-                tp,
-                thumb,
-                extern_url,
-                encrypt_url,
-            ]) {
+            if let Some(best) =
+                best_emoticon_url_from_fields(&[cdn, tp, thumb, extern_url, encrypt_url])
+            {
                 seen_md5.insert(md5);
                 urls.push(best);
             }
@@ -1111,13 +1208,9 @@ fn extract_urls_from_emoticon_db(emoticon_db: &Path, db_key: &str) -> anyhow::Re
             if !seen_md5.insert(md5) {
                 continue;
             }
-            if let Some(best) = best_emoticon_url_from_fields(&[
-                cdn,
-                tp,
-                thumb,
-                extern_url,
-                encrypt_url,
-            ]) {
+            if let Some(best) =
+                best_emoticon_url_from_fields(&[cdn, tp, thumb, extern_url, encrypt_url])
+            {
                 urls.push(best);
             }
         }
@@ -1127,7 +1220,8 @@ fn extract_urls_from_emoticon_db(emoticon_db: &Path, db_key: &str) -> anyhow::Re
 }
 
 async fn cmd_key(cli: &Cli, args: &KeyArgs) -> anyhow::Result<()> {
-    let accounts = find_accounts()?;
+    let data_root = xwechat_files_dir(cli.wechat_data_dir.as_deref())?;
+    let accounts = find_accounts(&data_root)?;
     let account = if let Some(wxid) = &args.wxid {
         let wxid = wxid.trim().to_string();
         accounts
@@ -1137,7 +1231,7 @@ async fn cmd_key(cli: &Cli, args: &KeyArgs) -> anyhow::Result<()> {
                 anyhow!("未找到账号：{wxid}（可先运行 `wxemoticon urls --list-accounts`）")
             })?
     } else {
-        select_account(&accounts, cli.no_interactive)?
+        select_account(&accounts, &data_root, cli.no_interactive)?
     };
 
     let key_file = if let Some(p) = &args.out {
@@ -1160,6 +1254,7 @@ async fn cmd_key(cli: &Cli, args: &KeyArgs) -> anyhow::Result<()> {
 
     let key = get_or_dump_key(
         &account.wxid,
+        &account.emoticon_db,
         &wechat_app,
         &key_file,
         &log_file,
@@ -1191,6 +1286,8 @@ async fn cmd_key(cli: &Cli, args: &KeyArgs) -> anyhow::Result<()> {
     if args.open {
         #[cfg(target_os = "macos")]
         open_reveal(&key_file)?;
+        #[cfg(target_os = "linux")]
+        open_reveal(&key_file)?;
     }
     Ok(())
 }
@@ -1202,12 +1299,13 @@ async fn cmd_urls(cli: &Cli, args: &UrlsArgs) -> anyhow::Result<()> {
         ));
     }
 
-    let accounts = find_accounts()?;
+    let data_root = xwechat_files_dir(cli.wechat_data_dir.as_deref())?;
+    let accounts = find_accounts(&data_root)?;
     if args.list_accounts {
         if accounts.is_empty() {
             println!(
                 "未找到账号（目录不存在或未登录微信）：{}",
-                xwechat_files_dir()?.display()
+                data_root.display()
             );
             return Ok(());
         }
@@ -1226,7 +1324,7 @@ async fn cmd_urls(cli: &Cli, args: &UrlsArgs) -> anyhow::Result<()> {
                 anyhow!("未找到账号：{wxid}（可先运行 `wxemoticon urls --list-accounts`）")
             })?
     } else {
-        select_account(&accounts, cli.no_interactive)?
+        select_account(&accounts, &data_root, cli.no_interactive)?
     };
 
     let out_file = if let Some(p) = &args.out {
@@ -1260,6 +1358,7 @@ async fn cmd_urls(cli: &Cli, args: &UrlsArgs) -> anyhow::Result<()> {
 
     let mut db_key = get_or_dump_key(
         &account.wxid,
+        &account.emoticon_db,
         &wechat_app,
         &key_file,
         &key_log,
@@ -1291,6 +1390,7 @@ async fn cmd_urls(cli: &Cli, args: &UrlsArgs) -> anyhow::Result<()> {
                 );
                 db_key = get_or_dump_key(
                     &account.wxid,
+                    &account.emoticon_db,
                     &wechat_app,
                     &key_file,
                     &key_log,
@@ -1353,6 +1453,8 @@ async fn cmd_urls(cli: &Cli, args: &UrlsArgs) -> anyhow::Result<()> {
     if args.open {
         #[cfg(target_os = "macos")]
         open_reveal(&out_file)?;
+        #[cfg(target_os = "linux")]
+        open_reveal(&out_file)?;
     }
     Ok(())
 }
@@ -1371,14 +1473,15 @@ async fn cmd_export(cli: &Cli, args: &ExportArgs) -> anyhow::Result<()> {
         }
     } else {
         // Reuse the `urls` pipeline.
-        let accounts = find_accounts()?;
+        let data_root = xwechat_files_dir(cli.wechat_data_dir.as_deref())?;
+        let accounts = find_accounts(&data_root)?;
         let account = if let Some(wx) = &args.wxid {
             let wx = wx.trim().to_string();
             accounts.into_iter().find(|a| a.wxid == wx).ok_or_else(|| {
                 anyhow!("未找到账号：{wx}（可先运行 `wxemoticon urls --list-accounts`）")
             })?
         } else {
-            select_account(&accounts, cli.no_interactive)?
+            select_account(&accounts, &data_root, cli.no_interactive)?
         };
         wxid = Some(account.wxid.clone());
 
@@ -1397,6 +1500,7 @@ async fn cmd_export(cli: &Cli, args: &ExportArgs) -> anyhow::Result<()> {
 
         let mut db_key = get_or_dump_key(
             &account.wxid,
+            &account.emoticon_db,
             &wechat_app,
             &key_file,
             &key_log,
@@ -1423,6 +1527,7 @@ async fn cmd_export(cli: &Cli, args: &ExportArgs) -> anyhow::Result<()> {
                     );
                     db_key = get_or_dump_key(
                         &account.wxid,
+                        &account.emoticon_db,
                         &wechat_app,
                         &key_file,
                         &key_log,
@@ -1508,19 +1613,18 @@ async fn cmd_export(cli: &Cli, args: &ExportArgs) -> anyhow::Result<()> {
             .ok()
             .map(|mut it| it.next().is_some())
             .unwrap_or(false)
+        && !cli.no_interactive
     {
-        if !cli.no_interactive {
-            let ok = Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt(format!(
-                    "目录已存在且非空：{}，继续写入？",
-                    out_dir.display()
-                ))
-                .default(false)
-                .interact_on(&term_stderr())
-                .unwrap_or(false);
-            if !ok {
-                return Err(anyhow!("已取消"));
-            }
+        let ok = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!(
+                "目录已存在且非空：{}，继续写入？",
+                out_dir.display()
+            ))
+            .default(false)
+            .interact_on(&term_stderr())
+            .unwrap_or(false);
+        if !ok {
+            return Err(anyhow!("已取消"));
         }
     }
 
@@ -1565,12 +1669,10 @@ async fn cmd_export(cli: &Cli, args: &ExportArgs) -> anyhow::Result<()> {
     let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(args.concurrency.max(1)));
     let mut handles = Vec::with_capacity(jobs.len());
     for (idx, url) in jobs {
-        if args.skip_existing {
-            if export_existing_file(&out_dir, idx, group_size, &url).is_some() {
-                skipped += 1;
-                pb.inc(1);
-                continue;
-            }
+        if args.skip_existing && export_existing_file(&out_dir, idx, group_size, &url).is_some() {
+            skipped += 1;
+            pb.inc(1);
+            continue;
         }
         let permit = sem.clone().acquire_owned().await?;
         let client = client.clone();
@@ -1633,11 +1735,14 @@ async fn cmd_export(cli: &Cli, args: &ExportArgs) -> anyhow::Result<()> {
     if args.open {
         #[cfg(target_os = "macos")]
         open_dir(&out_dir)?;
+        #[cfg(target_os = "linux")]
+        open_dir(&out_dir)?;
     }
 
     Ok(())
 }
 
+#[allow(unreachable_code)]
 async fn cmd_update(args: &UpdateArgs) -> anyhow::Result<()> {
     #[cfg(not(target_os = "macos"))]
     {
@@ -1693,7 +1798,10 @@ async fn cmd_update(args: &UpdateArgs) -> anyhow::Result<()> {
             ),
         ];
         if version != "latest" {
-            env_parts.push(format!("WXEMOTICON_VERSION={}", shell_single_quote(&version)));
+            env_parts.push(format!(
+                "WXEMOTICON_VERSION={}",
+                shell_single_quote(&version)
+            ));
         }
 
         let cmdline = format!(
@@ -1731,11 +1839,48 @@ async fn cmd_update(args: &UpdateArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn shell_single_quote(input: &str) -> String {
     if input.is_empty() {
         return "''".to_string();
     }
     format!("'{}'", input.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use super::*;
+
+    #[test]
+    fn linux_global_paths_are_parsed() {
+        let cli = Cli::try_parse_from([
+            "wxemoticon",
+            "--wechat-bin",
+            "/opt/custom/wechat",
+            "--wechat-data-dir",
+            "/data/xwechat_files",
+            "urls",
+            "--list-accounts",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.wechat_app, "/opt/custom/wechat");
+        assert_eq!(cli.wechat_data_dir.as_deref(), Some("/data/xwechat_files"));
+    }
+
+    #[test]
+    fn legacy_wechat_app_flag_remains_an_alias() {
+        let cli = Cli::try_parse_from([
+            "wxemoticon",
+            "--wechat-app",
+            "/Applications/WeChat.app",
+            "urls",
+            "--list-accounts",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.wechat_app, "/Applications/WeChat.app");
+    }
 }
 
 fn resolve_user_path(input: &str) -> anyhow::Result<PathBuf> {
@@ -1756,10 +1901,7 @@ fn parse_urls_from_text(input: &str) -> Vec<String> {
     let mut out = Vec::<String>::new();
     let mut seen = HashSet::<String>::new();
     for m in re.find_iter(input) {
-        let u = m
-            .as_str()
-            .trim()
-            .trim_end_matches(|c: char| c == '"' || c == '\'' || c == ')');
+        let u = m.as_str().trim().trim_end_matches(['"', '\'', ')']);
         if seen.insert(u.to_string()) {
             out.push(u.to_string());
         }
@@ -1918,7 +2060,11 @@ fn file_key_from_url(url: &str, fallback_index0: usize) -> String {
     format!("{:06}", fallback_index0 + 1)
 }
 
-async fn download_one(client: &Client, url: &str, fallback_index0: usize) -> anyhow::Result<Downloaded> {
+async fn download_one(
+    client: &Client,
+    url: &str,
+    fallback_index0: usize,
+) -> anyhow::Result<Downloaded> {
     let candidates = stodownload_candidates(url);
     let mut last_err: Option<anyhow::Error> = None;
     for c in candidates {
@@ -1936,7 +2082,9 @@ async fn download_one(client: &Client, url: &str, fallback_index0: usize) -> any
                 let bytes = resp.bytes().await.context("读取响应失败")?.to_vec();
                 let ext = ext_from_bytes(&bytes)
                     .map(|s| s.to_string())
-                    .or_else(|| ext_from_content_type(content_type.as_deref()).map(|s| s.to_string()))
+                    .or_else(|| {
+                        ext_from_content_type(content_type.as_deref()).map(|s| s.to_string())
+                    })
                     .or_else(|| ext_from_url(&c))
                     .unwrap_or_else(|| "gif".to_string());
                 let file_key = file_key_from_url(&c, fallback_index0);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,6 +19,8 @@ use sha2::Sha512;
 use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::{Command, Stdio};
@@ -312,6 +314,43 @@ fn default_out_dir() -> anyhow::Result<PathBuf> {
     }
 }
 
+fn ensure_private_dir(path: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(path)
+        .with_context(|| format!("创建缓存目录失败：{}", path.display()))?;
+    #[cfg(unix)]
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("设置缓存目录权限失败：{}", path.display()))?;
+    Ok(())
+}
+
+fn ensure_private_default_out_dir() -> anyhow::Result<PathBuf> {
+    let path = default_out_dir()?;
+    ensure_private_dir(&path)?;
+    Ok(path)
+}
+
+fn write_private_file(path: &Path, content: &[u8]) -> anyhow::Result<()> {
+    let parent = path.parent().ok_or_else(|| anyhow!("无效输出路径"))?;
+    if parent == default_out_dir()?.as_path() {
+        ensure_private_default_out_dir()?;
+    } else {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("创建输出目录失败：{}", parent.display()))?;
+    }
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("写入文件失败：{}", path.display()))?;
+    #[cfg(unix)]
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("设置文件权限失败：{}", path.display()))?;
+    file.write_all(content)
+        .with_context(|| format!("写入文件失败：{}", path.display()))
+}
+
 fn default_key_file() -> anyhow::Result<PathBuf> {
     Ok(default_out_dir()?.join("emoticon_dbkey.txt"))
 }
@@ -349,8 +388,8 @@ fn urls_log_for_wxid(wxid: &str) -> anyhow::Result<PathBuf> {
 fn xwechat_files_dir(explicit: Option<&str>) -> anyhow::Result<PathBuf> {
     #[cfg(target_os = "linux")]
     {
-        let explicit = explicit.map(Path::new);
-        linux::discover_data_root(&home_dir()?, explicit)
+        let explicit = explicit.map(resolve_user_path).transpose()?;
+        linux::discover_data_root(&home_dir()?, explicit.as_deref())
     }
     #[cfg(target_os = "macos")]
     {
@@ -528,6 +567,56 @@ fn read_first_line(path: &Path) -> Option<String> {
     content.lines().next().map(|s| s.trim().to_string())
 }
 
+fn database_page_matches_key(page: &[u8], key_bytes: &[u8], treat_as_passphrase: bool) -> bool {
+    const PAGE_SIZE: usize = 4096;
+    const SALT_SIZE: usize = 16;
+    const KEY_SIZE: usize = 32;
+    const HMAC_OFFSET: usize = 4032;
+    const ROUND_COUNT: u32 = 256_000;
+
+    if page.len() != PAGE_SIZE || key_bytes.len() != KEY_SIZE {
+        return false;
+    }
+    if page.starts_with(b"SQLite format 3") {
+        return true;
+    }
+    let salt = &page[..SALT_SIZE];
+    let key = if treat_as_passphrase {
+        pbkdf2_hmac_array::<Sha512, KEY_SIZE>(key_bytes, salt, ROUND_COUNT)
+    } else {
+        let mut key = [0u8; KEY_SIZE];
+        key.copy_from_slice(key_bytes);
+        key
+    };
+    let mac_salt: Vec<u8> = salt.iter().map(|byte| byte ^ 0x3a).collect();
+    let mac_key = pbkdf2_hmac_array::<Sha512, KEY_SIZE>(&key, &mac_salt, 2);
+    let Ok(mut mac) = Hmac::<Sha512>::new_from_slice(&mac_key) else {
+        return false;
+    };
+    mac.update(&page[SALT_SIZE..HMAC_OFFSET]);
+    mac.update(&1u32.to_le_bytes());
+    mac.verify_slice(&page[HMAC_OFFSET..]).is_ok()
+}
+
+fn database_matches_key(path: &Path, key_hex: &str) -> bool {
+    use std::io::Read;
+
+    let Some(key_hex) = normalize_hex_key(key_hex) else {
+        return false;
+    };
+    let Ok(key) = hex::decode(key_hex) else {
+        return false;
+    };
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut page = [0u8; 4096];
+    if file.read_exact(&mut page).is_err() {
+        return false;
+    }
+    database_page_matches_key(&page, &key, true) || database_page_matches_key(&page, &key, false)
+}
+
 fn seed_key_file_from_legacy(dst: &Path) {
     if dst.exists() {
         return;
@@ -544,10 +633,7 @@ fn seed_key_file_from_legacy(dst: &Path) {
     let Some(k) = normalize_hex_key(&line) else {
         return;
     };
-    if let Some(parent) = dst.parent() {
-        std::fs::create_dir_all(parent).ok();
-    }
-    let _ = std::fs::write(dst, format!("{k}\n"));
+    let _ = write_private_file(dst, format!("{k}\n").as_bytes());
 }
 
 fn append_log(path: &Path, line: &str) {
@@ -846,24 +932,36 @@ fn get_or_dump_key(
     force: bool,
     timeout: Duration,
 ) -> anyhow::Result<String> {
+    if key_file.parent() == Some(default_out_dir()?.as_path()) {
+        ensure_private_default_out_dir()?;
+    }
     if !force && key_file.exists() {
         if let Some(line) = read_first_line(key_file) {
             if let Some(k) = normalize_hex_key(&line) {
-                return Ok(k);
+                if database_matches_key(emoticon_db, &k) {
+                    write_private_file(key_file, format!("{k}\n").as_bytes())?;
+                    return Ok(k);
+                }
+                append_log(
+                    log_file,
+                    "[warn] cached key does not match the selected database; refreshing it",
+                );
             }
         }
     }
 
     #[cfg(target_os = "macos")]
     {
-        dump_db_key(
+        let key = dump_db_key(
             wechat_app,
             target_wxid,
             key_file,
             log_file,
             no_interactive,
             timeout,
-        )
+        )?;
+        write_private_file(key_file, format!("{key}\n").as_bytes())?;
+        Ok(key)
     }
     #[cfg(target_os = "linux")]
     {
@@ -871,11 +969,7 @@ fn get_or_dump_key(
         let _ = no_interactive;
         wait_for_wechat_exit(wechat_app, no_interactive)?;
         let key = linux::dump_db_key(wechat_app, emoticon_db, log_file, timeout)?;
-        if let Some(parent) = key_file.parent() {
-            std::fs::create_dir_all(parent).ok();
-        }
-        std::fs::write(key_file, format!("{key}\n"))
-            .with_context(|| format!("写入 key 文件失败：{}", key_file.display()))?;
+        write_private_file(key_file, format!("{key}\n").as_bytes())?;
         Ok(key)
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
@@ -1266,7 +1360,7 @@ async fn cmd_key(cli: &Cli, args: &KeyArgs) -> anyhow::Result<()> {
     // Keep legacy cache file for compatibility with the app/scripts.
     if let Ok(legacy) = default_key_file() {
         if legacy != key_file {
-            let _ = std::fs::write(&legacy, format!("{key}\n"));
+            let _ = write_private_file(&legacy, format!("{key}\n").as_bytes());
         }
     }
 
@@ -1414,7 +1508,7 @@ async fn cmd_urls(cli: &Cli, args: &UrlsArgs) -> anyhow::Result<()> {
     // Keep legacy cache files for compatibility with the app/scripts.
     if let Ok(legacy_key) = default_key_file() {
         if legacy_key != key_file {
-            let _ = std::fs::write(&legacy_key, format!("{db_key}\n"));
+            let _ = write_private_file(&legacy_key, format!("{db_key}\n").as_bytes());
         }
     }
     if let Ok(legacy_urls) = default_urls_file() {
@@ -1491,7 +1585,7 @@ async fn cmd_export(cli: &Cli, args: &ExportArgs) -> anyhow::Result<()> {
         let key_log = key_log_for_wxid(&account.wxid)?;
         let wechat_app = resolve_user_path(&cli.wechat_app)?;
 
-        std::fs::create_dir_all(default_out_dir()?).ok();
+        ensure_private_default_out_dir()?;
         let _ = std::fs::remove_file(&urls_file);
         let _ = std::fs::remove_file(&urls_log);
         let _ = std::fs::write(&urls_log, "");
@@ -1554,7 +1648,7 @@ async fn cmd_export(cli: &Cli, args: &ExportArgs) -> anyhow::Result<()> {
         // Keep legacy cache files for compatibility with the app/scripts.
         if let Ok(legacy_key) = default_key_file() {
             if legacy_key != key_file {
-                let _ = std::fs::write(&legacy_key, format!("{db_key}\n"));
+                let _ = write_private_file(&legacy_key, format!("{db_key}\n").as_bytes());
             }
         }
         if let Ok(legacy_urls) = default_urls_file() {
@@ -1850,6 +1944,7 @@ fn shell_single_quote(input: &str) -> String {
 #[cfg(test)]
 mod cli_tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn linux_global_paths_are_parsed() {
@@ -1880,6 +1975,44 @@ mod cli_tests {
         .unwrap();
 
         assert_eq!(cli.wechat_app, "/Applications/WeChat.app");
+    }
+
+    #[test]
+    fn database_key_validation_rejects_a_stale_key() {
+        let key = [0x31; 32];
+        let mut page = [0u8; 4096];
+        for (index, byte) in page[..4032].iter_mut().enumerate() {
+            *byte = (index % 251) as u8;
+        }
+        let salt = &page[..16];
+        let mac_salt: Vec<u8> = salt.iter().map(|byte| byte ^ 0x3a).collect();
+        let mac_key = pbkdf2_hmac_array::<Sha512, 32>(&key, &mac_salt, 2);
+        let mut mac = Hmac::<Sha512>::new_from_slice(&mac_key).unwrap();
+        mac.update(&page[16..4032]);
+        mac.update(&1u32.to_le_bytes());
+        page[4032..].copy_from_slice(&mac.finalize().into_bytes());
+
+        assert!(database_page_matches_key(&page, &key, false));
+        assert!(!database_page_matches_key(&page, &[0x32; 32], false));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_cache_permissions_are_restricted() {
+        let tmp = tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        ensure_private_dir(&cache).unwrap();
+        let secret = cache.join("key.txt");
+        write_private_file(&secret, b"secret\n").unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&cache).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(&secret).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2014,6 +2014,18 @@ mod cli_tests {
             0o600
         );
     }
+
+    #[test]
+    fn download_candidates_fall_back_to_the_tls_valid_wechat_cdn_host() {
+        let source = "https://vweixinf.tc.qq.com/110/20401/stodownload.webp?m=abc&hy=SZ";
+
+        let candidates = stodownload_candidates(source);
+
+        assert_eq!(candidates[0], source);
+        assert!(candidates.contains(
+            &"https://wxapp.tc.qq.com/110/20401/stodownload.webp?m=abc&hy=SZ".to_string()
+        ));
+    }
 }
 
 fn resolve_user_path(input: &str) -> anyhow::Result<PathBuf> {
@@ -2073,20 +2085,32 @@ struct Downloaded {
 }
 
 fn stodownload_candidates(url: &str) -> Vec<String> {
-    if !url.contains("/stodownload") {
-        return vec![url.to_string()];
-    }
     let exts = ["gif", "jpg", "png", "webp"];
     let mut out = Vec::<String>::new();
     let mut seen = HashSet::<String>::new();
 
     let mut push = |s: String| {
         if seen.insert(s.clone()) {
-            out.push(s);
+            out.push(s.clone());
+        }
+        let Ok(mut parsed) = Url::parse(&s) else {
+            return;
+        };
+        if parsed.host_str() == Some("vweixinf.tc.qq.com")
+            && parsed.set_host(Some("wxapp.tc.qq.com")).is_ok()
+        {
+            let fallback = parsed.to_string();
+            if seen.insert(fallback.clone()) {
+                out.push(fallback);
+            }
         }
     };
 
     push(url.to_string());
+
+    if !url.contains("/stodownload") {
+        return out;
+    }
 
     // Replace `/stodownload` or `/stodownload.xxx` right before `?`.
     // Keep order: original -> gif/jpg/png/webp variants.

--- a/docs/superpowers/plans/2026-07-17-linux-cli.md
+++ b/docs/superpowers/plans/2026-07-17-linux-cli.md
@@ -1,0 +1,67 @@
+# Linux CLI 导出实现计划
+
+> **面向 AI 代理的工作者：** 在当前会话内按 TDD 红—绿—重构顺序逐项执行。
+
+**目标：** 让 `wxemoticon` 在 Ubuntu/Debian x86_64 与腾讯官方 Linux 微信 4.x 上直接完成账号发现、密钥获取、URL 提取和图片导出。
+
+**架构：** 保留现有单二进制 CLI 和 macOS 路径；新增小型 `linux` 模块负责 XDG 文档目录发现、`/proc` 进程识别、可读内存区解析和 WCDB key 候选扫描。Linux 自动取 key 时由 CLI 启动 `/opt/wechat/wechat`，轮询主进程及后代，并使用目标 `emoticon.db` 的第一页 HMAC 校验候选 key。
+
+**技术栈：** Rust 2021、Clap、Linux `/proc`、SQLCipher4、现有 AES/HMAC/PBKDF2 解密代码。
+
+---
+
+### 任务 1：Linux 路径与账号发现
+
+**文件：**
+- 创建：`cli/src/linux.rs`
+- 修改：`cli/src/main.rs`
+
+- [ ] 在 `linux.rs` 写失败测试，覆盖 `~/Documents/xwechat_files`、本地化 `~/文档/xwechat_files`、显式 `--wechat-data-dir` 优先级和无效目录。
+- [ ] 运行 `cargo test --manifest-path cli/Cargo.toml linux::tests::data_root`，确认因 API 缺失失败。
+- [ ] 实现 `discover_data_root` 与基于传入根目录的 `find_accounts_in`。
+- [ ] 运行测试并确认通过。
+
+### 任务 2：内存映射与 key 候选扫描
+
+**文件：**
+- 修改：`cli/src/linux.rs`
+- 修改：`cli/src/main.rs`
+
+- [ ] 写失败测试，覆盖 `/proc/<pid>/maps` 行解析、跨块 ASCII `x'<64hex><32hex>'` 候选、纯 64 hex 候选去重和非 hex 排除。
+- [ ] 运行定向测试，确认失败原因是扫描器尚未实现。
+- [ ] 实现 `MemoryRegion`、流式块扫描与候选迭代器；候选值不写日志。
+- [ ] 用现有 `decrypt_db_file_v4_with_key` 验证目标数据库第一页对应的 raw key。
+- [ ] 运行全部 CLI 单元测试。
+
+### 任务 3：Linux 微信生命周期和自动取 key
+
+**文件：**
+- 修改：`cli/src/linux.rs`
+- 修改：`cli/src/main.rs`
+- 修改：`cli/Cargo.toml`
+
+- [ ] 写失败测试，覆盖微信进程识别、父子进程表解析和超时错误。
+- [ ] 实现当前用户微信进程检测、退出门禁、启动 `/opt/wechat/wechat`、扫描启动进程及其后代、成功或超时时清理本次启动的进程。
+- [ ] 将 `get_or_dump_key` 的 Linux 分支接入扫描器；已有合法 key 文件仍优先复用。
+- [ ] 运行单元测试和 `cargo check`，确保 macOS 条件编译未被破坏。
+
+### 任务 4：CLI 参数和桌面目录操作
+
+**文件：**
+- 修改：`cli/src/main.rs`
+
+- [ ] 写 Clap 解析测试，覆盖 `--wechat-bin`、`--wechat-data-dir` 和旧 `--wechat-app` 兼容别名。
+- [ ] 将 Linux 默认输出改为 `~/.local/share/wxemoticon`，默认导出仍为 `~/Downloads`。
+- [ ] Linux `--open` 使用 `xdg-open`；Linux `update` 返回明确的源码安装提示。
+- [ ] 运行全部 CLI 测试。
+
+### 任务 5：文档、构建和真实链路验证
+
+**文件：**
+- 修改：`README.md`
+- 修改：`scripts/install-wxemoticon.sh`
+
+- [ ] 补充 Ubuntu/Debian x86_64 构建、安装、权限模型和 `wxemoticon export` 示例。
+- [ ] 运行 `cargo fmt --manifest-path cli/Cargo.toml -- --check`、`cargo test --manifest-path cli/Cargo.toml`、`cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`、`cargo build --manifest-path cli/Cargo.toml --release`。
+- [ ] 在当前 Ubuntu 24.04/微信 4.1.1.7 上运行脱敏的 `urls --list-accounts`。
+- [ ] 经用户已接受的退出/重启流程，验证 `key`、`urls`，最后用临时目录执行小范围导出；日志只报告数量和脱敏路径。


### PR DESCRIPTION
## What changed

- add Linux support for the `wxemoticon` CLI
- discover Tencent WeChat 4.x account data on Linux
- extract and validate database keys with bounded process cleanup
- export emoji URLs and images with CDN fallback
- document Linux build and usage instructions
- sanitize account examples and ignore generated key/URL artifacts

## Why

The GUI currently targets macOS, while Linux users need a supported command-line workflow for Tencent WeChat 4.x.

## Impact

Ubuntu/Debian x86_64 users can build and run `wxemoticon` to list accounts and export favorite emoji. Existing macOS behavior remains supported.

## Validation

- `cargo test --manifest-path cli/Cargo.toml` (21 passed)
- `vitest run` (9 passed)
- `tsc -p tsconfig.json --noEmit`
- sensitive identifier and secret-pattern scan of added content